### PR TITLE
reverting tokens to 2048

### DIFF
--- a/slack_gpt_bot.py
+++ b/slack_gpt_bot.py
@@ -96,7 +96,7 @@ def command_handler(body, context):
             model="gpt-3.5-turbo",
             messages=messages,
             stream=True,
-            max_tokens=4096
+            max_tokens=2048
         )
         
         response_text = ""


### PR DESCRIPTION
- The last PR was unable to be deployed due to token constraints we hadn't quite figured out.  Goal here is to fix the token size back into the main branch so we can deploy it with the previous logging changes. 
-  based off parameters here: [https://platform.openai.com/docs/api-reference/chat/create](url)