### PR TITLE
ARCHIE-207 - Fix Logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -190,7 +190,7 @@ def handle_app_mentions(body, context):
             thread_ts=thread_ts,
             user=user.username, 
             email=user.email,
-            request=messages[1:],   #field 0 is something that gets added as part of process_conversation_history that we don't need
+            request=messages[-1],   #field 0 is something that gets added as part of process_conversation_history that we don't need
             response=response_text
         )
     
@@ -202,7 +202,7 @@ def handle_app_mentions(body, context):
             thread_ts=thread_ts,
             user=user.username, 
             email=user.email,
-            request=messages[1:],
+            request=messages[-1],
             exception=e
         )
         app.client.chat_postMessage(

--- a/main.py
+++ b/main.py
@@ -190,7 +190,7 @@ def handle_app_mentions(body, context):
             thread_ts=thread_ts,
             user=user.username, 
             email=user.email,
-            request=messages[-1],   #field 0 is something that gets added as part of process_conversation_history that we don't need
+            request=messages[-1],   #Get the last request from the messages array
             response=response_text
         )
     

--- a/slack_gpt_bot.py
+++ b/slack_gpt_bot.py
@@ -192,7 +192,7 @@ def handle_app_mentions(body, context):
             thread_ts=thread_ts,
             user=user.username, 
             email=user.email,
-            request=messages[1:],   #field 0 is something that gets added as part of process_conversation_history that we don't need
+            request=messages[-1],   #field 0 is something that gets added as part of process_conversation_history that we don't need
             response=response_text
         )
     
@@ -204,7 +204,7 @@ def handle_app_mentions(body, context):
             thread_ts=thread_ts,
             user=user.username, 
             email=user.email,
-            request=messages[1:],
+            request=messages[-1],
             exception=e
         )
         app.client.chat_postMessage(

--- a/slack_gpt_bot.py
+++ b/slack_gpt_bot.py
@@ -192,7 +192,7 @@ def handle_app_mentions(body, context):
             thread_ts=thread_ts,
             user=user.username, 
             email=user.email,
-            request=messages[-1],   #field 0 is something that gets added as part of process_conversation_history that we don't need
+            request=messages[-1],   #Get the last request from the messages array
             response=response_text
         )
     


### PR DESCRIPTION
https://cipherhealth.atlassian.net/browse/ARCHIE-207

Changed the logging approach to just log the last request instead of the entire conversation history with each request. With the 16k model, this history approach could exceed log entry limitations in GCP. If this happens, the log is just dropped, which results in missing logs in Cloud Logging. 

No change to OpenAI context, so thread history is preserved when communicating with the OpenAI chat API. Only changed logging.