### PR TITLE
ARCHIE-235: Slack profile keys first_name and last_name are not guaranteed 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 slack_bolt
 Flask>=1.1
 gunicorn>=20
-openai
+openai==0.28
 tiktoken
 trafilatura
 json-logger-stdout

--- a/slack_gpt_bot.py
+++ b/slack_gpt_bot.py
@@ -173,7 +173,6 @@ class SlackGPTBot:
             user_id = context['user_id']
 
             #Impersonate A User Here
-            user_id = "U01AQPTGL6T"
 
             self.logging_wrapper("Milestone", logging.DEBUG, 
                     milestone="Fetching user information from slack",

--- a/slack_gpt_bot.py
+++ b/slack_gpt_bot.py
@@ -172,15 +172,10 @@ class SlackGPTBot:
             bot_user_id = context['bot_user_id']
             user_id = context['user_id']
 
-            #Use Sheela's id for testing
-            user_id = "URRC5BGAF"
-
             self.logging_wrapper("Milestone", logging.DEBUG, 
                     milestone="Fetching user information from slack",
                     user_id=user_id)
             user = self.get_user_information(user_id)
-
-            print(user)
 
             '''
             How to lock the bot to a particular channel

--- a/slack_gpt_bot.py
+++ b/slack_gpt_bot.py
@@ -172,6 +172,9 @@ class SlackGPTBot:
             bot_user_id = context['bot_user_id']
             user_id = context['user_id']
 
+            #Impersonate A User Here
+            user_id = "U01AQPTGL6T"
+
             self.logging_wrapper("Milestone", logging.DEBUG, 
                     milestone="Fetching user information from slack",
                     user_id=user_id)


### PR DESCRIPTION
https://cipherhealth.atlassian.net/browse/ARCHIE-235

https://cipherhealth.atlassian.net/servicedesk/customer/portal/5/CIT-1311

Sheetal Meheshwari is not able to use the Cipher GPT Slack chat bot due to the JSON data the bot gets back from the Slack user_info API. When the bot was written, user.profile.first_name and user.profile.last_name seemed to be guaranteed keys in the response, however that appears not to be the case any longer, at least in Sheetal's case (she is the only person I am aware of that is experiencing this). The bot was extracting first name and last name from the profile, but only using the first name - for a personalization effect. However, in Sheetal's case, the bot throws a KeyError exception and drops the request because first_name is not present in the response (neither is last_name).

To resolve the issue:

- Slack profile keys, first_name and last_name, were dropped in favor of real_name
- using GCP Duet, a small function was created to extract the first name from the real_name to preserve the personalization.
- KeyError handling was tested by impersonating Sheetal's profile in requests that came from myself (since I was not able to figure out how to get those fields from my Slack profile) with first_name and last_name key extraction still in place in the code.
- User impersonation was also done to test users whose real_name only has their first name to make sure that the personalization message was unaffected. These users were Tyler, Markus, Suzie, and Ekin. Requests came from me, but instead of my Slack profile ID, I swapped in theirs. This was a read operation, their profiles were not altered.
- KeyErrors from Slack will not cause the bot to ignore the request any longer, instead, a User object is created using only the user_id, and that user_id has also been added to the logs so that the request can be traced back.

Some lingering remnants of the last refactoring were also cleaned up to be sure that the right app instance was being used.

