### PR TITLE
ARCHIE-237: Update our Slack GPT Chat Bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ Additional logging components have been added for compliance purposes to track a
 See `requirements.txt`.
 
 # Installation
-## Building the bot 
+## Building the WebSocket Bot 
 Build the container (generic)
 ```
-docker build . -t slack-gpt-bot
+docker build . -f Dockerfile.websockets -t slack-gpt-bot:TAG
 ```
 Tag it for the GCR (Generic example)
 ```
-docker tag slack-gpt-bot us.gcr.io/PROJECT_ID/slack-gpt-bot:TAG
+docker tag slack-gpt-bot:TAG us.gcr.io/PROJECT_ID/slack-gpt-bot:TAG
 ```
 Push to the GCR (Generic example)
 ```
@@ -39,9 +39,11 @@ docker push us.gcr.io/PROJECT_ID/slack-gpt-bot:TAG
 ***Beta Specifics***
 
 ```
-docker build . -t slack-gpt-bot
-docker tag slack-gpt-bot us.gcr.io/qaload-track-atlas-ch-e4e9/slack-gpt-bot:latest
-docker push us.gcr.io/qaload-track-atlas-ch-e4e9/slack-gpt-bot:latest
+docker build . -f Dockerfile.websockets -t slack-gpt-bot:v<tag>
+docker tag slack-gpt-bot:<tag> us.gcr.io/qaload-track-atlas-ch-e4e9/slack-gpt-bot:<tag>
+docker push us.gcr.io/qaload-track-atlas-ch-e4e9/slack-gpt-bot:<tag>
+git tag -a v<TAG> -m <message>
+git push origin v<TAG>
 ```
 ## Deploying the bot
 The bot leverages sockets which do not play nice with CloudRun, as such it is to be deployed as a container to GCE directly.

--- a/main_flask.py
+++ b/main_flask.py
@@ -3,11 +3,11 @@ Slack GPT Chat Bot
 Powered by a Slack Request URL, /slack/events, and the Python Flask framework
 '''
 
-from slack_gpt_bot import (SlackGPTBot, OPENAI_MODEL_4_DEFAULT)
+from slack_gpt_bot import (SlackGPTBot)
 from slack_bolt import App
 
 app = App()
-slack_gpt_bot = SlackGPTBot(app, OPENAI_MODEL_4_DEFAULT)
+slack_gpt_bot = SlackGPTBot(app)
 
 ################################################
 

--- a/main_websocket.py
+++ b/main_websocket.py
@@ -5,11 +5,11 @@ Powered by a Slack Websockets
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 
-from slack_gpt_bot import (SlackGPTBot, OPENAI_MODEL_4_DEFAULT)
+from slack_gpt_bot import (SlackGPTBot)
 from utils import (SLACK_BOT_TOKEN, SLACK_APP_TOKEN)
 
 app = App(token=SLACK_BOT_TOKEN)
-slack_gpt_bot = SlackGPTBot(app, OPENAI_MODEL_4_DEFAULT)
+slack_gpt_bot = SlackGPTBot(app)
 
 ################################################
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 slack_bolt
 Flask>=1.1
 gunicorn>=20
-openai==0.28
+openai
 tiktoken
 trafilatura
 json-logger-stdout

--- a/slack_gpt_bot.py
+++ b/slack_gpt_bot.py
@@ -24,6 +24,11 @@ else:
 OPENAI_MODEL_4_OHHHH = "gpt-4o"
 OPENAI_MODEL_4_OHHHH_TOKENS = 128000
 
+#based on the way tokens are counted for other models, this 
+#is roughly the max length of a single Slack message in tokens
+#(4000) characters
+OPENAI_MODEL_4_OHHHH_MAX_TOKENS = 730
+
 #-----------------------------------------------
 # Model to use
 OPENAI_MODEL_IN_USE = OPENAI_MODEL_4_OHHHH
@@ -235,7 +240,8 @@ class SlackGPTBot:
             openai_response = self.openai_client.chat.completions.create(
                 model=self.model_to_use,
                 messages=messages,
-                stream=True
+                stream=True,
+                max_tokens=OPENAI_MODEL_4_OHHHH_MAX_TOKENS
             )
 
             slack_update_func = partial(update_chat, self.app, channel_id, reply_message_ts)

--- a/utils.py
+++ b/utils.py
@@ -81,7 +81,7 @@ def num_tokens_from_messages(messages, model="gpt-4"):
     elif model == "gpt-3.5-turbo-0301":
         tokens_per_message = 4  # every message follows <|start|>{role/name}\n{content}<|end|>\n
         tokens_per_name = -1  # if there's a name, the role is omitted
-    elif model == "gpt-4-0314":
+    elif model == "gpt-4-0314" or model == "gpt-4o":
         tokens_per_message = 3
         tokens_per_name = 1
     else:


### PR DESCRIPTION
https://cipherhealth.atlassian.net/browse/ARCHIE-237

OpenAI has implemented Project API keys which have replaced user API keys. So I had to create a new project in OpenAI
![Screenshot 2024-05-17 at 4 28 13 PM](https://github.com/SolarCS/slack-gpt-bot/assets/7561730/763c18ee-da7f-49b6-8ab6-84e8b66f5302)
I also created a service account for the project and created a project key associated with that account. This will be the key that the app will use going forward.

Also OpenAI has made several changes to their Python library which needed to be included in the update. Particularly how the key is passed to the client and a new API for chat (and some changes to how streaming works.)

Finally, OpenAI also release their latest model, GPT-4o. So support for that has been added as well.
